### PR TITLE
Add crossinline version of benchmark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,25 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jmh.version>1.19</jmh.version>
         <javac.target>1.8</javac.target>
-        <kotlin.version>1.2.0</kotlin.version>
+        <kotlin.version>1.2.40-eap-16</kotlin.version>
         <coroutines.version>0.20</coroutines.version>
 
         <jmh.generator>default</jmh.generator>
         <uberjar.name>benchmarks</uberjar.name>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>kotlin-eap</id>
+            <url>https://dl.bintray.com/kotlin/kotlin-eap</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>kotlin-eap</id>
+            <url>https://dl.bintray.com/kotlin/kotlin-eap</url>
+        </pluginRepository>
+    </pluginRepositories>
 
     <dependencies>
         <dependency>

--- a/src/main/kotlin/benchmark/RangeFilterSumBenchmark.kt
+++ b/src/main/kotlin/benchmark/RangeFilterSumBenchmark.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.experimental.rx2.rxObservable
 import org.openjdk.jmh.annotations.*
 import reactor.core.publisher.Flux
 import source.*
+import sourceCrossinline.*
 import sourceInline.*
 import srcmanbase.*
 import java.util.concurrent.TimeUnit
@@ -114,6 +115,14 @@ open class RangeFilterSumBenchmark {
         sequenceGenerateRange(1, N)
             .filter { it.isGood() }
             .fold(0, { a, b -> a + b })
+
+    @Benchmark
+    fun testSourceCrossInline(): Int = runBlocking {
+        SourceCrossinline
+                .range(1, N)
+                .filter { it.isGood() }
+                .fold(0, { a, b -> a + b })
+    }
 
     @Benchmark
     fun testSequenceBuild(): Int =

--- a/src/main/kotlin/source/SourceCrossinline.kt
+++ b/src/main/kotlin/source/SourceCrossinline.kt
@@ -1,0 +1,76 @@
+package sourceCrossinline
+
+import kotlinx.coroutines.experimental.DefaultDispatcher
+import kotlinx.coroutines.experimental.channels.Channel
+import kotlinx.coroutines.experimental.channels.consumeEach
+import kotlinx.coroutines.experimental.launch
+import kotlin.coroutines.experimental.CoroutineContext
+
+// -------------- Interface definitions
+
+interface SourceCrossinline<out E> {
+    suspend fun consume(sink: Sink<E>)
+    companion object Factory
+}
+
+interface Sink<in E> {
+    suspend fun send(item: E)
+    fun close(cause: Throwable?)
+}
+
+// -------------- Factory (initial/producing) operations
+
+inline fun <E> source(crossinline action: suspend Sink<E>.() -> Unit): SourceCrossinline<E> = object : SourceCrossinline<E> {
+    override suspend fun consume(sink: Sink<E>) {
+        var cause: Throwable? = null
+        try {
+            action(sink)
+        } catch (e: Throwable) {
+            cause = e
+        }
+        sink.close(cause)
+    }
+}
+
+fun SourceCrossinline.Factory.range(start: Int, count: Int): SourceCrossinline<Int> = source<Int> {
+    for (i in start until (start + count)) {
+        send(i)
+    }
+}
+
+// -------------- Terminal (final/consuming) operations
+
+suspend inline fun <E> SourceCrossinline<E>.consumeEach(crossinline action: suspend (E) -> Unit) {
+    consume(object : Sink<E> {
+        override suspend fun send(item: E) = action(item)
+        override fun close(cause: Throwable?) { cause?.let { throw it } }
+    })
+}
+
+suspend inline fun <E, R> SourceCrossinline<E>.fold(initial: R, crossinline operation: suspend (acc: R, E) -> R): R {
+    var acc = initial
+    consumeEach {
+        acc = operation(acc, it)
+    }
+    return acc
+}
+
+// -------------- Intermediate (transforming) operations
+
+inline fun <E> SourceCrossinline<E>.filter(crossinline predicate: (E) -> Boolean) = source<E> {
+    consumeEach {
+        if (predicate(it)) send(it)
+    }
+}
+
+fun <E> SourceCrossinline<E>.async(context: CoroutineContext = DefaultDispatcher, buffer: Int = 0): SourceCrossinline<E> {
+    val channel = Channel<E>(buffer)
+    return object : SourceCrossinline<E> {
+        override suspend fun consume(sink: Sink<E>) {
+            launch(context) {
+                channel.consumeEach { sink.send(it) }
+            }
+            this@async.consumeEach { channel.send(it) }
+        }
+    }
+}


### PR DESCRIPTION
In the last kotlin eap build support of crossinline suspend lambdas has been added.
Update the benchmark to measure the change.